### PR TITLE
Refactor beacon/probe methods

### DIFF
--- a/Eiredynamic.Pharos/Beacon.cs
+++ b/Eiredynamic.Pharos/Beacon.cs
@@ -27,12 +27,31 @@ namespace Eiredynamic.Pharos
             _config = config;
         }
         public async Task SendBeacon(CancellationToken cancellationToken, T item)
-        { 
+        {
             if (item is null)
             {
                 throw new ArgumentNullException(nameof(item));
             }
 
+            byte[] buffer = Serialize(item);
+            await SendBeaconLoop(cancellationToken, () => buffer);
+        }
+
+        public async Task SendBeacon(CancellationToken cancellationToken, Func<T> getItem)
+        {
+            await SendBeaconLoop(cancellationToken, () =>
+            {
+                T item = getItem();
+                if (item is null)
+                {
+                    throw new ArgumentNullException(nameof(getItem));
+                }
+                return Serialize(item);
+            });
+        }
+
+        private byte[] Serialize(T item)
+        {
             byte[] buffer;
             try
             {
@@ -43,49 +62,15 @@ namespace Eiredynamic.Pharos
                 _logger.Error(ex, $"Serialization failed for type {typeof(T).Name}. Check that all properties are serializable and properly decorated with [JsonProperty] if needed.");
                 throw new InvalidOperationException($"Beacon serialization failed for type {typeof(T).Name}.", ex);
             }
-            if (buffer.Length > 1400) _logger.Warn($"Beacon payload for {typeof(T).Name} may exceed safe UDP limits ({buffer.Length} bytes)");
 
-            using (UdpClient sender = new UdpClient(_config.SourcePort))
-            {
-                sender.AllowNatTraversal(true);
-                IPEndPoint _multicastEndpoint = new IPEndPoint(_config.MulticastIP, _config.DestinationPort);
-                _logger.Info($"Starting beacon to send to {_config.MulticastIP}:{_config.DestinationPort}");
-                
-                while (!cancellationToken.IsCancellationRequested)
-                {
-#pragma warning disable S2139 // Re-throwing caught exception
-                    try
-                    {
-                        await sender.SendAsync(buffer, buffer.Length, _multicastEndpoint);
-                        _logger.Trace($"Sent beacon of type {typeof(T).Name}");
-                        // Wait for a period before sending the next beacon (e.g., 5 seconds)
-                        await Task.Delay(_config.BeaconInterval, cancellationToken);
-                    }
-                    catch (SocketException ex)
-                    {
-                        _logger.Error(ex, "Failed to send beacon. Network may be unreachable or multicast misconfigured.");
-                        break;
-                    }
+            if (buffer.Length > 1400)
+                _logger.Warn($"Beacon payload for {typeof(T).Name} may exceed safe UDP limits ({buffer.Length} bytes)");
 
-                    catch (Exception ex) when (ex is not OperationCanceledException)
-                    {
-                        _logger.Error(ex, "Unexpected error during beacon send.");
-                        throw;
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        break;
-                    }
-#pragma warning restore S2139
-                }
-                _logger.Info("Cancellation requested. Beacon stopped.");
-            }
+            return buffer;
         }
 
-        public async Task SendBeacon(CancellationToken cancellationToken, Func<T> getItem)
+        private async Task SendBeaconLoop(CancellationToken cancellationToken, Func<byte[]> getBuffer)
         {
-            
-
             using (UdpClient sender = new UdpClient(_config.SourcePort))
             {
                 sender.AllowNatTraversal(true);
@@ -94,29 +79,12 @@ namespace Eiredynamic.Pharos
 
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    T item = getItem();
-                    if (item is null)
-                    {
-                        throw new ArgumentNullException(nameof(getItem));
-                    }
-                    byte[] buffer;
-                    try
-                    {
-                        buffer = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(item));
-                    }
-                    catch (JsonSerializationException ex)
-                    {
-                        _logger.Error(ex, $"Serialization failed for type {typeof(T).Name}. Check that all properties are serializable and properly decorated with [JsonProperty] if needed.");
-                        throw new InvalidOperationException($"Beacon serialization failed for type {typeof(T).Name}.", ex);
-                    }
-                    if (buffer.Length > 1400) _logger.Warn($"Beacon payload for {typeof(T).Name} may exceed safe UDP limits ({buffer.Length} bytes)");
-
 #pragma warning disable S2139 // Re-throwing caught exception
+                    byte[] buffer = getBuffer();
                     try
                     {
                         await sender.SendAsync(buffer, buffer.Length, _multicastEndpoint);
                         _logger.Trace($"Sent beacon of type {typeof(T).Name}");
-                        // Wait for a period before sending the next beacon (e.g., 5 seconds)
                         await Task.Delay(_config.BeaconInterval, cancellationToken);
                     }
                     catch (SocketException ex)
@@ -124,7 +92,7 @@ namespace Eiredynamic.Pharos
                         _logger.Error(ex, "Failed to send beacon. Network may be unreachable or multicast misconfigured.");
                         break;
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         _logger.Error(ex, "Unexpected error during beacon send.");
                         throw;

--- a/Eiredynamic.Pharos/Probe.cs
+++ b/Eiredynamic.Pharos/Probe.cs
@@ -47,10 +47,28 @@ public class Probe<T>: IProbe<T> where T : class
 
     public async IAsyncEnumerable<T> StartReceiving([EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        await foreach (var item in ReceiveMessages(cancellationToken))
+        {
+            yield return item;
+        }
+    }
+
+    public async Task StartReceivingWithEventsOnly(CancellationToken cancellationToken)
+    {
+        await foreach (var item in ReceiveMessages(cancellationToken))
+        {
+            OnEvent?.Invoke(this, new ProbeEventArgs<T>(item));
+        }
+        _logger.Info("Event-only probe shut down.");
+    }
+
+    private async IAsyncEnumerable<T> ReceiveMessages([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
         if (_udpClient == null)
         {
             _udpClient = new UdpClientWrapper(new UdpClient());
         }
+
         using (_udpClient)
         {
             IPEndPoint _endPoint = new IPEndPoint(IPAddress.Any, _config.DestinationPort);
@@ -59,24 +77,22 @@ public class Probe<T>: IProbe<T> where T : class
             _udpClient.ExclusiveAddressUse = false;
             _udpClient.Bind(_endPoint);
 
-            // Join the multicast group on the local network interface
             _udpClient.JoinMulticastGroup(_config.MulticastIP);
-
             _logger.Info($"Listening for multicast messages on {_config.MulticastIP}:{_config.DestinationPort}");
+
             while (!cancellationToken.IsCancellationRequested)
             {
                 UdpReceiveResult result;
                 try
                 {
-                    // Wait for a multicast message to arrive but allow cancellation so doesn't block indefinitely
                     var receiveTask = _udpClient.ReceiveAsync();
-                    var cancelTask = Task.Delay(Timeout.Infinite, cancellationToken); // Will complete if canceled
+                    var cancelTask = Task.Delay(Timeout.Infinite, cancellationToken);
                     var completedTask = await Task.WhenAny(receiveTask, cancelTask);
                     if (completedTask == cancelTask)
                     {
-                        // Cancellation was requested, so exit loop
                         break;
                     }
+
                     result = await receiveTask;
                 }
                 catch (SocketException ex)
@@ -89,8 +105,7 @@ public class Probe<T>: IProbe<T> where T : class
                     _logger.Error(ex, "Unexpected error during beacon reception.");
                     throw;
                 }
-            
-                // We know receiveTask is completed because we checked it above
+
                 if (result.Buffer == null || result.Buffer.Length == 0)
                 {
                     _logger.Warn($"Received empty or null beacon from {result.RemoteEndPoint}. Ignored.");
@@ -99,7 +114,7 @@ public class Probe<T>: IProbe<T> where T : class
 
                 string json = Encoding.UTF8.GetString(result.Buffer);
                 _logger.Trace($"Received beacon from {result.RemoteEndPoint}");
-                
+
                 T obj = null;
                 try
                 {
@@ -119,6 +134,7 @@ public class Probe<T>: IProbe<T> where T : class
                     _logger.Warn($"Deserialization returned null for beacon from {result.RemoteEndPoint}. Ignored.");
                 }
             }
+
             try
             {
                 _udpClient.DropMulticastGroup(_config.MulticastIP);
@@ -129,81 +145,6 @@ public class Probe<T>: IProbe<T> where T : class
                 _logger.Warn(ex, "Failed to leave multicast group cleanly.");
             }
             _logger.Info("Cancellation requested. Probe stopped.");
-        }
-    }
-
-    public async Task StartReceivingWithEventsOnly(CancellationToken cancellationToken)
-    {
-        if (_udpClient == null)
-        {
-            _udpClient = new UdpClientWrapper(new UdpClient());
-        }
-
-        using (_udpClient)
-        {
-            IPEndPoint _endPoint = new IPEndPoint(IPAddress.Any, _config.DestinationPort);
-            _udpClient.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-            _udpClient.AllowNatTraversal(true);
-            _udpClient.ExclusiveAddressUse = false;
-            _udpClient.Bind(_endPoint);
-
-            _udpClient.JoinMulticastGroup(_config.MulticastIP);
-            _logger.Info($"Listening (event-only) on {_config.MulticastIP}:{_config.DestinationPort}");
-
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                UdpReceiveResult result;
-                try
-                {
-                    var receiveTask = _udpClient.ReceiveAsync();
-                    var cancelTask = Task.Delay(Timeout.Infinite, cancellationToken);
-                    var completedTask = await Task.WhenAny(receiveTask, cancelTask);
-                    if (completedTask == cancelTask)
-                        break;
-
-                    result = await receiveTask;
-                }
-                catch (SocketException ex)
-                {
-                    _logger.Error(ex, "Socket error in event-only probe.");
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error(ex, "Unhandled error in event-only probe.");
-                    throw;
-                }
-
-                if (result.Buffer == null || result.Buffer.Length == 0)
-                    continue;
-
-                string json = Encoding.UTF8.GetString(result.Buffer);
-                _logger.Trace($"Received beacon (event-only) from {result.RemoteEndPoint}");
-
-                try
-                {
-                    var obj = JsonConvert.DeserializeObject<T>(json);
-                    if (obj != null)
-                    {
-                        OnEvent?.Invoke(this, new ProbeEventArgs<T>(obj));
-                    }
-                }
-                catch (JsonException ex)
-                {
-                    _logger.Warn(ex, "Deserialization failed for beacon (event-only).");
-                }
-            }
-
-            try
-            {
-                _udpClient.DropMulticastGroup(_config.MulticastIP);
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn(ex, "Failed to leave multicast group cleanly (event-only).");
-            }
-
-            _logger.Info("Event-only probe shut down.");
         }
     }
 


### PR DESCRIPTION
## Summary
- refactor Beacon to share common beacon logic
- refactor Probe to share receive loop

## Testing
- `dotnet test` *(fails: requires .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68405519b838832ab172708d12ddcee6