### PR TITLE
Update framework to net9.0 and refactor Beacon config

### DIFF
--- a/Eiredynamic.Pharos.Tests/Eiredynamic.Pharos.Tests.csproj
+++ b/Eiredynamic.Pharos.Tests/Eiredynamic.Pharos.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Eiredynamic.Pharos.Tests/PharosBeaconTests.cs
+++ b/Eiredynamic.Pharos.Tests/PharosBeaconTests.cs
@@ -44,6 +44,7 @@ namespace Eiredynamic.Pharos.Tests
 
             // Assert
             Assert.NotNull(beacon);
+            Assert.Equal(_config.MulticastIP, beacon.config.MulticastIP);
         }
 
         [Fact]

--- a/Eiredynamic.Pharos/Beacon.cs
+++ b/Eiredynamic.Pharos/Beacon.cs
@@ -16,15 +16,15 @@ namespace Eiredynamic.Pharos
     public class Beacon<T> : IBeacon<T> where T : class
     {
         private readonly static Logger _logger = LogManager.GetCurrentClassLogger();
-        private readonly ConfigOptions _config;
+        public readonly ConfigOptions config;
 
         public Beacon() { 
-            _config = new ConfigOptions();
+            config = new ConfigOptions();
         }
 
         public Beacon(ConfigOptions config)
         {
-            _config = config;
+            this.config = config;
         }
         public async Task SendBeacon(CancellationToken cancellationToken, T item)
         {
@@ -71,11 +71,11 @@ namespace Eiredynamic.Pharos
 
         private async Task SendBeaconLoop(CancellationToken cancellationToken, Func<byte[]> getBuffer)
         {
-            using (UdpClient sender = new UdpClient(_config.SourcePort))
+            using (UdpClient sender = new UdpClient(config.SourcePort))
             {
                 sender.AllowNatTraversal(true);
-                IPEndPoint _multicastEndpoint = new IPEndPoint(_config.MulticastIP, _config.DestinationPort);
-                _logger.Info($"Starting beacon to send to {_config.MulticastIP}:{_config.DestinationPort}");
+                IPEndPoint _multicastEndpoint = new IPEndPoint(config.MulticastIP, config.DestinationPort);
+                _logger.Info($"Starting beacon to send to {config.MulticastIP}:{config.DestinationPort}");
 
                 while (!cancellationToken.IsCancellationRequested)
                 {
@@ -85,7 +85,7 @@ namespace Eiredynamic.Pharos
                     {
                         await sender.SendAsync(buffer, buffer.Length, _multicastEndpoint);
                         _logger.Trace($"Sent beacon of type {typeof(T).Name}");
-                        await Task.Delay(_config.BeaconInterval, cancellationToken);
+                        await Task.Delay(config.BeaconInterval, cancellationToken);
                     }
                     catch (SocketException ex)
                     {

--- a/Eiredynamic.Pharos/Eiredynamic.Pharos.csproj
+++ b/Eiredynamic.Pharos/Eiredynamic.Pharos.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>13.0</LangVersion>
     <PackageId>Eiredynamic.Pharos</PackageId>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <Authors>eiredynamic</Authors>
     <Description>Pharos is a .NET discovery library that enables beacon/probe detection and serialized message exchange.</Description>
     <Copyright>eiredynamic</Copyright>


### PR DESCRIPTION
- Changed target framework from net8.0 to net9.0 in Eiredynamic.Pharos.Tests.csproj.
- Added assertion in PharosBeaconTests to verify config.
- Refactored Beacon class: changed _config to public readonly config.
- Updated SendBeaconLoop to use the new config field.
- Incremented version from 1.3.3 to 1.3.4 in Eiredynamic.Pharos.csproj.